### PR TITLE
Feat/setup di and navigation

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,16 +1,18 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-kapt'
+    id 'dagger.hilt.android.plugin'
 }
 
 android {
     namespace 'com.ferdinand.pdftestapp'
-    compileSdk 32
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.ferdinand.pdftestapp"
         minSdk 23
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0"
 
@@ -48,16 +50,32 @@ android {
 
 dependencies {
 
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.3.1'
-    implementation 'androidx.activity:activity-compose:1.3.1'
-    implementation "androidx.compose.ui:ui:$compose_ui_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_ui_version"
-    implementation 'androidx.compose.material:material:1.1.1'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation "androidx.appcompat:appcompat:1.5.1"
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
+    implementation 'androidx.activity:activity-compose:1.6.0'
+    implementation "androidx.compose.ui:ui:$composeUIVersion"
+    implementation "androidx.compose.ui:ui-tooling-preview:$composeUIVersion"
+    implementation 'androidx.compose.material:material:1.2.1'
+
+    // Navigation
+    implementation "androidx.navigation:navigation-fragment-ktx:$navVersion"
+    implementation "androidx.navigation:navigation-ui-ktx:$navVersion"
+
+    //Hilt
+    implementation "com.google.dagger:hilt-android:$rootProject.hiltVersion"
+    kapt "com.google.dagger:hilt-android-compiler:$rootProject.hiltVersion"
+
+    //Timber
+    implementation "com.jakewharton.timber:timber:$rootProject.timberVersion"
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_ui_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_ui_version"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_ui_version"
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$composeUIVersion"
+    debugImplementation "androidx.compose.ui:ui-tooling:$composeUIVersion"
+    debugImplementation "androidx.compose.ui:ui-test-manifest:$composeUIVersion"
+}
+kapt {
+    correctErrorTypes true
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".PdfTestApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -15,7 +16,6 @@
         <activity
             android:name=".MainActivity"
             android:exported="true"
-            android:label="@string/app_name"
             android:theme="@style/Theme.PdfTestApp">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/ferdinand/pdftestapp/MainActivity.kt
+++ b/app/src/main/java/com/ferdinand/pdftestapp/MainActivity.kt
@@ -1,40 +1,14 @@
 package com.ferdinand.pdftestapp
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
-import androidx.activity.compose.setContent
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import com.ferdinand.pdftestapp.ui.theme.PdfTestAppTheme
+import androidx.appcompat.app.AppCompatActivity
+import dagger.hilt.android.AndroidEntryPoint
 
-class MainActivity : ComponentActivity() {
+@AndroidEntryPoint
+class MainActivity : AppCompatActivity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContent {
-            PdfTestAppTheme {
-                // A surface container using the 'background' color from the theme
-                Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background) {
-                    Greeting("Android")
-                }
-            }
-        }
-    }
-}
-
-@Composable
-fun Greeting(name: String) {
-    Text(text = "Hello $name!")
-}
-
-@Preview(showBackground = true)
-@Composable
-fun DefaultPreview() {
-    PdfTestAppTheme {
-        Greeting("Android")
+        setContentView(R.layout.activity_main)
     }
 }

--- a/app/src/main/java/com/ferdinand/pdftestapp/TmdbApplication.kt
+++ b/app/src/main/java/com/ferdinand/pdftestapp/TmdbApplication.kt
@@ -1,0 +1,20 @@
+package com.ferdinand.pdftestapp
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+import timber.log.Timber
+
+@HiltAndroidApp
+class PdfTestApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        initTimber()
+    }
+
+    private fun initTimber() {
+        if (BuildConfig.DEBUG) {
+            Timber.plant(Timber.DebugTree())
+        }
+    }
+}

--- a/app/src/main/java/com/ferdinand/pdftestapp/main/PdfListFragment.kt
+++ b/app/src/main/java/com/ferdinand/pdftestapp/main/PdfListFragment.kt
@@ -1,0 +1,32 @@
+package com.ferdinand.pdftestapp.main
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.Fragment
+import com.ferdinand.pdftestapp.ui.theme.PdfTestAppTheme
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class PdfListFragment : Fragment() {
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                PdfTestAppTheme {
+                    // A surface container using the 'background' color from the theme
+                    Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background) {
+                        Text("Hello Android")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/ferdinand/pdftestapp/main/PdfListFragment.kt
+++ b/app/src/main/java/com/ferdinand/pdftestapp/main/PdfListFragment.kt
@@ -8,22 +8,29 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
 import com.ferdinand.pdftestapp.ui.theme.PdfTestAppTheme
+import com.ferdinand.pdftestapp.viewmodel.PdfViewModel
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class PdfListFragment : Fragment() {
 
+    private val viewModel: PdfViewModel by viewModels()
+
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         return ComposeView(requireContext()).apply {
             setContent {
+                val text by viewModel.placeholder.collectAsState()
                 PdfTestAppTheme {
                     // A surface container using the 'background' color from the theme
                     Surface(modifier = Modifier.fillMaxSize(), color = MaterialTheme.colors.background) {
-                        Text("Hello Android")
+                        Text(text = text)
                     }
                 }
             }

--- a/app/src/main/java/com/ferdinand/pdftestapp/viewmodel/PdfViewModel.kt
+++ b/app/src/main/java/com/ferdinand/pdftestapp/viewmodel/PdfViewModel.kt
@@ -2,8 +2,12 @@ package com.ferdinand.pdftestapp.viewmodel
 
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import javax.inject.Inject
 
 @HiltViewModel
 class PdfViewModel @Inject constructor() : ViewModel() {
+
+    val placeholder = MutableStateFlow("Hello Android").asStateFlow()
 }

--- a/app/src/main/java/com/ferdinand/pdftestapp/viewmodel/PdfViewModel.kt
+++ b/app/src/main/java/com/ferdinand/pdftestapp/viewmodel/PdfViewModel.kt
@@ -1,0 +1,9 @@
+package com.ferdinand.pdftestapp.viewmodel
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class PdfViewModel @Inject constructor() : ViewModel() {
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/main_nav_host_fragment"
+        android:name="androidx.navigation.fragment.NavHostFragment"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:defaultNavHost="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navGraph="@navigation/main_graph" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/navigation/main_graph.xml
+++ b/app/src/main/res/navigation/main_graph.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/main_graph.xml"
+    app:startDestination="@id/pdfListFragment">
+
+    <fragment
+        android:id="@+id/pdfListFragment"
+        android:name="com.ferdinand.pdftestapp.main.PdfListFragment"
+        android:label="@string/label_all_pdf_files" />
+</navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">PdfTestApp</string>
+    <string name="label_all_pdf_files">All Pdf files</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="Theme.PdfTestApp" parent="android:Theme.Material.Light.NoActionBar">
+    <style name="Theme.PdfTestApp" parent="Theme.MaterialComponents.Light.NoActionBar">
         <item name="android:statusBarColor">@color/purple_700</item>
     </style>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,12 @@
 buildscript {
     ext {
-        compose_ui_version = '1.1.1'
+        composeUIVersion = '1.2.1'
+        navVersion = "2.5.2"
+        hiltVersion = '2.43.2'
+        timberVersion = '5.0.1'
+    }
+    dependencies {
+        classpath "com.google.dagger:hilt-android-gradle-plugin:$hiltVersion"
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {


### PR DESCRIPTION
This PR does the following:
1. Setup DI with dagger hilt
2. Use older navigation component, which is more flexible than navigation compose
3. Add placeholder text for use with jetpack compose in main fragment